### PR TITLE
Enforce compilation order

### DIFF
--- a/lib/beepbop/utils.ex
+++ b/lib/beepbop/utils.ex
@@ -7,6 +7,7 @@ defmodule BeepBop.Utils do
   """
   @msg_not_a_struct "does not define a struct"
   @msg_missing_column "doesn't have any column named:"
+  @msg_not_loaded "could not be loaded"
 
   @msg_from_atom_list "bad 'from'/'not_from': should be a list of atoms, got: "
   @msg_from_empty "bad 'from': cannot be empty!"
@@ -44,12 +45,16 @@ defmodule BeepBop.Utils do
   end
 
   def assert_schema!(schema, column) do
-    unless function_exported?(schema, :__schema__, 1) do
-      raise("#{inspect(schema)} #{@msg_not_a_struct}")
-    end
+    if Code.ensure_compiled?(schema) do
+      unless function_exported?(schema, :__schema__, 1) do
+        raise("#{inspect(schema)} #{@msg_not_a_struct}")
+      end
 
-    unless column in schema.__schema__(:fields) do
-      raise("#{inspect(schema)} #{@msg_missing_column} #{inspect(column)}")
+      unless column in schema.__schema__(:fields) do
+        raise("#{inspect(schema)} #{@msg_missing_column} #{inspect(column)}")
+      end
+    else
+      raise("#{inspect(schema)} #{@msg_not_loaded}")
     end
   end
 

--- a/test/beepbop/utils_test.exs
+++ b/test/beepbop/utils_test.exs
@@ -9,6 +9,7 @@ defmodule BeepBop.UtilsTest do
   """
   @msg_not_a_struct " does not define a struct"
   @msg_missing_column "doesn't have any column named:"
+  @msg_not_loaded "could not be loaded"
 
   @msg_from_atom_list "bad 'from'/'not_from': should be a list of atoms, got: "
   @msg_from_empty "bad 'from': cannot be empty!"
@@ -68,6 +69,10 @@ defmodule BeepBop.UtilsTest do
         Utils.assert_schema!(CardPayment, :tricked)
       end
     )
+
+    assert_raise(RuntimeError, "FooBar #{@msg_not_loaded}", fn ->
+      Utils.assert_schema!(FooBar, :foobar)
+    end)
   end
 
   test "assert_num_states!/1" do


### PR DESCRIPTION
It is important that the struct gets compiled _completely_ before the
state-machine module is defined. The compiler correctly infers the
compile-time dependency, but that doesn't stop it from compiling the
state-machine module _parallely_ (I guess).

Anyhow, placing ensure_compiled?/1 should help.

fixes #3